### PR TITLE
Feature/question detail more

### DIFF
--- a/DoriDori_iOS/DoriDori_iOS.xcodeproj/project.pbxproj
+++ b/DoriDori_iOS/DoriDori_iOS.xcodeproj/project.pbxproj
@@ -142,6 +142,7 @@
 		A266067728BFBE9200E54CBF /* WebViewCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = A266067628BFBE9200E54CBF /* WebViewCommand.swift */; };
 		A274345828D702D4000B10CC /* ActionSheetAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A274345728D702D4000B10CC /* ActionSheetAlertController.swift */; };
 		A274345B28D7048E000B10CC /* ReportRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A274345A28D7048E000B10CC /* ReportRequest.swift */; };
+		A2774D3C28E1D2470014365F /* DoriDoriQuestionPostDetailMore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2774D3B28E1D2470014365F /* DoriDoriQuestionPostDetailMore.swift */; };
 		A2934DFE289E33B900749D0B /* MyPageTabCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2934DFD289E33B900749D0B /* MyPageTabCollectionViewCell.swift */; };
 		A29C2AD728959B1C00CA5C49 /* MySpeechBubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29C2AD628959B1C00CA5C49 /* MySpeechBubbleView.swift */; };
 		A29C2AD928959DE700CA5C49 /* MyPageMySpeechBubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29C2AD828959DE700CA5C49 /* MyPageMySpeechBubbleView.swift */; };
@@ -373,6 +374,7 @@
 		A266067628BFBE9200E54CBF /* WebViewCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewCommand.swift; sourceTree = "<group>"; };
 		A274345728D702D4000B10CC /* ActionSheetAlertController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionSheetAlertController.swift; sourceTree = "<group>"; };
 		A274345A28D7048E000B10CC /* ReportRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportRequest.swift; sourceTree = "<group>"; };
+		A2774D3B28E1D2470014365F /* DoriDoriQuestionPostDetailMore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoriDoriQuestionPostDetailMore.swift; sourceTree = "<group>"; };
 		A2934DFD289E33B900749D0B /* MyPageTabCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageTabCollectionViewCell.swift; sourceTree = "<group>"; };
 		A29C2AD628959B1C00CA5C49 /* MySpeechBubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MySpeechBubbleView.swift; sourceTree = "<group>"; };
 		A29C2AD828959DE700CA5C49 /* MyPageMySpeechBubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageMySpeechBubbleView.swift; sourceTree = "<group>"; };
@@ -1103,6 +1105,7 @@
 				A2E105DF28BA0CB600CC6498 /* WebViewCoordinator.swift */,
 				A2E105E128BA139B00CC6498 /* DoriDoriWeb.swift */,
 				A266067628BFBE9200E54CBF /* WebViewCommand.swift */,
+				A2774D3B28E1D2470014365F /* DoriDoriQuestionPostDetailMore.swift */,
 			);
 			path = WebView;
 			sourceTree = "<group>";
@@ -1565,6 +1568,7 @@
 				A2CE622D28C11C130067CCAD /* EmptyCell.swift in Sources */,
 				A274345828D702D4000B10CC /* ActionSheetAlertController.swift in Sources */,
 				A266067728BFBE9200E54CBF /* WebViewCommand.swift in Sources */,
+				A2774D3C28E1D2470014365F /* DoriDoriQuestionPostDetailMore.swift in Sources */,
 				CE5B13342879AED500F10A20 /* HomeViewController.swift in Sources */,
 				CE6A451A28ABD3B20084B106 /* HomeSpeechModel.swift in Sources */,
 				A24FD13C28B2676400A003D1 /* QuestionToUserRequest.swift in Sources */,

--- a/DoriDori_iOS/DoriDori_iOS.xcodeproj/project.pbxproj
+++ b/DoriDori_iOS/DoriDori_iOS.xcodeproj/project.pbxproj
@@ -146,6 +146,7 @@
 		A2774D3E28E1D9740014365F /* QuestionPostDetailRequestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2774D3D28E1D9740014365F /* QuestionPostDetailRequestable.swift */; };
 		A2774D4128E1DA700014365F /* DeletePostRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2774D4028E1DA700014365F /* DeletePostRequest.swift */; };
 		A2774D4428E1DABD0014365F /* DeleteQuestionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2774D4328E1DABD0014365F /* DeleteQuestionRequest.swift */; };
+		A2774D4728E1E28D0014365F /* BlockUserRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2774D4628E1E28D0014365F /* BlockUserRequest.swift */; };
 		A2934DFE289E33B900749D0B /* MyPageTabCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2934DFD289E33B900749D0B /* MyPageTabCollectionViewCell.swift */; };
 		A29C2AD728959B1C00CA5C49 /* MySpeechBubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29C2AD628959B1C00CA5C49 /* MySpeechBubbleView.swift */; };
 		A29C2AD928959DE700CA5C49 /* MyPageMySpeechBubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29C2AD828959DE700CA5C49 /* MyPageMySpeechBubbleView.swift */; };
@@ -381,6 +382,7 @@
 		A2774D3D28E1D9740014365F /* QuestionPostDetailRequestable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionPostDetailRequestable.swift; sourceTree = "<group>"; };
 		A2774D4028E1DA700014365F /* DeletePostRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeletePostRequest.swift; sourceTree = "<group>"; };
 		A2774D4328E1DABD0014365F /* DeleteQuestionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteQuestionRequest.swift; sourceTree = "<group>"; };
+		A2774D4628E1E28D0014365F /* BlockUserRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockUserRequest.swift; sourceTree = "<group>"; };
 		A2934DFD289E33B900749D0B /* MyPageTabCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageTabCollectionViewCell.swift; sourceTree = "<group>"; };
 		A29C2AD628959B1C00CA5C49 /* MySpeechBubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MySpeechBubbleView.swift; sourceTree = "<group>"; };
 		A29C2AD828959DE700CA5C49 /* MyPageMySpeechBubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageMySpeechBubbleView.swift; sourceTree = "<group>"; };
@@ -798,6 +800,7 @@
 		A24FD0EC28A5735400A003D1 /* APIs */ = {
 			isa = PBXGroup;
 			children = (
+				A2774D4528E1E27C0014365F /* UserController */,
 				A2774D4228E1DAB00014365F /* QuestionController */,
 				A2774D3F28E1DA620014365F /* PostController */,
 				A274345928D7047F000B10CC /* ReportController */,
@@ -1012,6 +1015,14 @@
 				A2774D4328E1DABD0014365F /* DeleteQuestionRequest.swift */,
 			);
 			path = QuestionController;
+			sourceTree = "<group>";
+		};
+		A2774D4528E1E27C0014365F /* UserController */ = {
+			isa = PBXGroup;
+			children = (
+				A2774D4628E1E28D0014365F /* BlockUserRequest.swift */,
+			);
+			path = UserController;
 			sourceTree = "<group>";
 		};
 		A2CF64DD28796D72007D54DD /* Network */ = {
@@ -1584,6 +1595,7 @@
 				6C350E6F28A159B5005281C2 /* NicknameSettingViewController.swift in Sources */,
 				6C94FC692887C9F000DD77B6 /* EmailSignUpViewModel.swift in Sources */,
 				6C1A660328892054005A3314 /* TermsOfServiceViewContoller.swift in Sources */,
+				A2774D4728E1E28D0014365F /* BlockUserRequest.swift in Sources */,
 				6C3D0B6728B48E6E0076450B /* TermsOfServiceRequest.swift in Sources */,
 				6CB65B5B2879792000C15E2B /* WelcomeViewController.swift in Sources */,
 				A219F63928BE48290065C1F9 /* TextFieldAlertViewController.swift in Sources */,

--- a/DoriDori_iOS/DoriDori_iOS.xcodeproj/project.pbxproj
+++ b/DoriDori_iOS/DoriDori_iOS.xcodeproj/project.pbxproj
@@ -143,6 +143,9 @@
 		A274345828D702D4000B10CC /* ActionSheetAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A274345728D702D4000B10CC /* ActionSheetAlertController.swift */; };
 		A274345B28D7048E000B10CC /* ReportRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A274345A28D7048E000B10CC /* ReportRequest.swift */; };
 		A2774D3C28E1D2470014365F /* DoriDoriQuestionPostDetailMore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2774D3B28E1D2470014365F /* DoriDoriQuestionPostDetailMore.swift */; };
+		A2774D3E28E1D9740014365F /* QuestionPostDetailRequestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2774D3D28E1D9740014365F /* QuestionPostDetailRequestable.swift */; };
+		A2774D4128E1DA700014365F /* DeletePostRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2774D4028E1DA700014365F /* DeletePostRequest.swift */; };
+		A2774D4428E1DABD0014365F /* DeleteQuestionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2774D4328E1DABD0014365F /* DeleteQuestionRequest.swift */; };
 		A2934DFE289E33B900749D0B /* MyPageTabCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2934DFD289E33B900749D0B /* MyPageTabCollectionViewCell.swift */; };
 		A29C2AD728959B1C00CA5C49 /* MySpeechBubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29C2AD628959B1C00CA5C49 /* MySpeechBubbleView.swift */; };
 		A29C2AD928959DE700CA5C49 /* MyPageMySpeechBubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29C2AD828959DE700CA5C49 /* MyPageMySpeechBubbleView.swift */; };
@@ -375,6 +378,9 @@
 		A274345728D702D4000B10CC /* ActionSheetAlertController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionSheetAlertController.swift; sourceTree = "<group>"; };
 		A274345A28D7048E000B10CC /* ReportRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportRequest.swift; sourceTree = "<group>"; };
 		A2774D3B28E1D2470014365F /* DoriDoriQuestionPostDetailMore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoriDoriQuestionPostDetailMore.swift; sourceTree = "<group>"; };
+		A2774D3D28E1D9740014365F /* QuestionPostDetailRequestable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionPostDetailRequestable.swift; sourceTree = "<group>"; };
+		A2774D4028E1DA700014365F /* DeletePostRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeletePostRequest.swift; sourceTree = "<group>"; };
+		A2774D4328E1DABD0014365F /* DeleteQuestionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteQuestionRequest.swift; sourceTree = "<group>"; };
 		A2934DFD289E33B900749D0B /* MyPageTabCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageTabCollectionViewCell.swift; sourceTree = "<group>"; };
 		A29C2AD628959B1C00CA5C49 /* MySpeechBubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MySpeechBubbleView.swift; sourceTree = "<group>"; };
 		A29C2AD828959DE700CA5C49 /* MyPageMySpeechBubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageMySpeechBubbleView.swift; sourceTree = "<group>"; };
@@ -792,6 +798,8 @@
 		A24FD0EC28A5735400A003D1 /* APIs */ = {
 			isa = PBXGroup;
 			children = (
+				A2774D4228E1DAB00014365F /* QuestionController */,
+				A2774D3F28E1DA620014365F /* PostController */,
 				A274345928D7047F000B10CC /* ReportController */,
 				6C296CA628B362D600E1BFD2 /* Auth */,
 				6C564FE628B9221500A91959 /* Profile */,
@@ -990,6 +998,22 @@
 			path = ReportController;
 			sourceTree = "<group>";
 		};
+		A2774D3F28E1DA620014365F /* PostController */ = {
+			isa = PBXGroup;
+			children = (
+				A2774D4028E1DA700014365F /* DeletePostRequest.swift */,
+			);
+			path = PostController;
+			sourceTree = "<group>";
+		};
+		A2774D4228E1DAB00014365F /* QuestionController */ = {
+			isa = PBXGroup;
+			children = (
+				A2774D4328E1DABD0014365F /* DeleteQuestionRequest.swift */,
+			);
+			path = QuestionController;
+			sourceTree = "<group>";
+		};
 		A2CF64DD28796D72007D54DD /* Network */ = {
 			isa = PBXGroup;
 			children = (
@@ -1106,6 +1130,7 @@
 				A2E105E128BA139B00CC6498 /* DoriDoriWeb.swift */,
 				A266067628BFBE9200E54CBF /* WebViewCommand.swift */,
 				A2774D3B28E1D2470014365F /* DoriDoriQuestionPostDetailMore.swift */,
+				A2774D3D28E1D9740014365F /* QuestionPostDetailRequestable.swift */,
 			);
 			path = WebView;
 			sourceTree = "<group>";
@@ -1425,6 +1450,7 @@
 				6C6529ED2895365A00EB04B5 /* PasswordViewModel.swift in Sources */,
 				6C86264228BCE9D600865FFA /* ProfileDefaultReqeust.swift in Sources */,
 				6C6529EB2895364B00EB04B5 /* PasswordInputViewController.swift in Sources */,
+				A2774D4428E1DABD0014365F /* DeleteQuestionRequest.swift in Sources */,
 				6C564FE828B9223D00A91959 /* NicknameRequest.swift in Sources */,
 				6CB65B622879AAB300C15E2B /* EmailSignInViewController.swift in Sources */,
 				6C350E7228A1619F005281C2 /* ProfileUploadViewController.swift in Sources */,
@@ -1433,6 +1459,7 @@
 				6C94FC682887C9F000DD77B6 /* EmailSignUpViewController.swift in Sources */,
 				CE6FF75828B135A300E4A3CD /* UIViewController+Extension.swift in Sources */,
 				A24FD14B28B356A100A003D1 /* MyWardDropDownItem.swift in Sources */,
+				A2774D3E28E1D9740014365F /* QuestionPostDetailRequestable.swift in Sources */,
 				CE5B13352879AED500F10A20 /* HomeViewModel.swift in Sources */,
 				A20A9E9C287982B5000ABFBB /* MyPageProfileView.swift in Sources */,
 				A2CF64E128796D8B007D54DD /* ErrorModel.swift in Sources */,
@@ -1460,6 +1487,7 @@
 				CE6A452128ABEB6E0084B106 /* UserDefault.swift in Sources */,
 				CE5E72B628BE3991002E97B9 /* RefreshModel.swift in Sources */,
 				CEB113B128BE88AC00C17D7A /* HomeRangeViewController.swift in Sources */,
+				A2774D4128E1DA700014365F /* DeletePostRequest.swift in Sources */,
 				CE8A535728996272005E33CC /* LocationCollectionViewCell.swift in Sources */,
 				CE42D3842870483A00C49548 /* CompositionRoot.swift in Sources */,
 				CE5B134D287A11B800F10A20 /* BaseWebViewController.swift in Sources */,

--- a/DoriDori_iOS/DoriDori_iOS.xcodeproj/project.pbxproj
+++ b/DoriDori_iOS/DoriDori_iOS.xcodeproj/project.pbxproj
@@ -140,6 +140,8 @@
 		A2655AE72899731600B03AA1 /* CommentableSpeechBubbleViewType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2655AE62899731600B03AA1 /* CommentableSpeechBubbleViewType.swift */; };
 		A2655AE92899751A00B03AA1 /* SpeechBubbleViewLikeable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2655AE82899751A00B03AA1 /* SpeechBubbleViewLikeable.swift */; };
 		A266067728BFBE9200E54CBF /* WebViewCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = A266067628BFBE9200E54CBF /* WebViewCommand.swift */; };
+		A274345828D702D4000B10CC /* ActionSheetAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A274345728D702D4000B10CC /* ActionSheetAlertController.swift */; };
+		A274345B28D7048E000B10CC /* ReportRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A274345A28D7048E000B10CC /* ReportRequest.swift */; };
 		A2934DFE289E33B900749D0B /* MyPageTabCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2934DFD289E33B900749D0B /* MyPageTabCollectionViewCell.swift */; };
 		A29C2AD728959B1C00CA5C49 /* MySpeechBubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29C2AD628959B1C00CA5C49 /* MySpeechBubbleView.swift */; };
 		A29C2AD928959DE700CA5C49 /* MyPageMySpeechBubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29C2AD828959DE700CA5C49 /* MyPageMySpeechBubbleView.swift */; };
@@ -369,6 +371,8 @@
 		A2655AE62899731600B03AA1 /* CommentableSpeechBubbleViewType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentableSpeechBubbleViewType.swift; sourceTree = "<group>"; };
 		A2655AE82899751A00B03AA1 /* SpeechBubbleViewLikeable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechBubbleViewLikeable.swift; sourceTree = "<group>"; };
 		A266067628BFBE9200E54CBF /* WebViewCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewCommand.swift; sourceTree = "<group>"; };
+		A274345728D702D4000B10CC /* ActionSheetAlertController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionSheetAlertController.swift; sourceTree = "<group>"; };
+		A274345A28D7048E000B10CC /* ReportRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportRequest.swift; sourceTree = "<group>"; };
 		A2934DFD289E33B900749D0B /* MyPageTabCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageTabCollectionViewCell.swift; sourceTree = "<group>"; };
 		A29C2AD628959B1C00CA5C49 /* MySpeechBubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MySpeechBubbleView.swift; sourceTree = "<group>"; };
 		A29C2AD828959DE700CA5C49 /* MyPageMySpeechBubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageMySpeechBubbleView.swift; sourceTree = "<group>"; };
@@ -770,6 +774,7 @@
 		A24FD0EB28A5734200A003D1 /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				A274345628D702C1000B10CC /* ActionSheet */,
 				A24FD15F28B4B2CD00A003D1 /* Alert */,
 				A24FD16428B4B48A00A003D1 /* ActivityIndicator */,
 				6C5E72A228AFCCB200013C2B /* TextField */,
@@ -785,6 +790,7 @@
 		A24FD0EC28A5735400A003D1 /* APIs */ = {
 			isa = PBXGroup;
 			children = (
+				A274345928D7047F000B10CC /* ReportController */,
 				6C296CA628B362D600E1BFD2 /* Auth */,
 				6C564FE628B9221500A91959 /* Profile */,
 				A24FD0ED28A5736100A003D1 /* UserInfoRequest.swift */,
@@ -964,6 +970,22 @@
 				A2655ADE28996E1500B03AA1 /* MyPageOtherSpeechBubbleItemType.swift */,
 			);
 			path = ItemType;
+			sourceTree = "<group>";
+		};
+		A274345628D702C1000B10CC /* ActionSheet */ = {
+			isa = PBXGroup;
+			children = (
+				A274345728D702D4000B10CC /* ActionSheetAlertController.swift */,
+			);
+			path = ActionSheet;
+			sourceTree = "<group>";
+		};
+		A274345928D7047F000B10CC /* ReportController */ = {
+			isa = PBXGroup;
+			children = (
+				A274345A28D7048E000B10CC /* ReportRequest.swift */,
+			);
+			path = ReportController;
 			sourceTree = "<group>";
 		};
 		A2CF64DD28796D72007D54DD /* Network */ = {
@@ -1393,6 +1415,7 @@
 				A219F63B28BE5EAC0065C1F9 /* ReplyCommentRequest.swift in Sources */,
 				6C5E72B928AFCCB200013C2B /* UnderLineTextFieldViewModel.swift in Sources */,
 				6C3D0B6C28B4919A0076450B /* TermsModel.swift in Sources */,
+				A274345B28D7048E000B10CC /* ReportRequest.swift in Sources */,
 				6C564FF428B926A500A91959 /* TokenModel.swift in Sources */,
 				6C5B741C28A49CB200D7DC9D /* ProfileKeywordView.swift in Sources */,
 				6C0172B928AA2A460081DDD4 /* SignUpRepository.swift in Sources */,
@@ -1540,6 +1563,7 @@
 				CE5B13382879B1DC00F10A20 /* HomeHeaderView.swift in Sources */,
 				CE5E72BB28BE4AA5002E97B9 /* HomeCoordinator.swift in Sources */,
 				A2CE622D28C11C130067CCAD /* EmptyCell.swift in Sources */,
+				A274345828D702D4000B10CC /* ActionSheetAlertController.swift in Sources */,
 				A266067728BFBE9200E54CBF /* WebViewCommand.swift in Sources */,
 				CE5B13342879AED500F10A20 /* HomeViewController.swift in Sources */,
 				CE6A451A28ABD3B20084B106 /* HomeSpeechModel.swift in Sources */,

--- a/DoriDori_iOS/DoriDori_iOS/Common/APIs/PostController/DeletePostRequest.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Common/APIs/PostController/DeletePostRequest.swift
@@ -1,0 +1,20 @@
+//
+//  DeletePostRequest.swift
+//  DoriDori_iOS
+//
+//  Created by Seori on 2022/09/26.
+//
+
+import Foundation
+
+struct DeletePostRequest: Requestable {
+    var path: String { "/api/v1/posts/\(self.postID)"}
+    var parameters: Parameter? { nil }
+    var method: HTTPMethod { .delete }
+    private let postID: PostID
+    init(
+        postID: PostID
+    ) {
+        self.postID = postID
+    }
+}

--- a/DoriDori_iOS/DoriDori_iOS/Common/APIs/QuestionController/DeleteQuestionRequest.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Common/APIs/QuestionController/DeleteQuestionRequest.swift
@@ -1,0 +1,22 @@
+//
+//  DeleteQuestionRequest.swift
+//  DoriDori_iOS
+//
+//  Created by Seori on 2022/09/26.
+//
+
+import Foundation
+
+struct DeleteQuestionRequest: Requestable {
+    var path: String { "/api/v1/questions/\(self.questionID)"}
+    var parameters: Parameter? { nil }
+    var method: HTTPMethod { .delete }
+    
+    private let questionID: QuestionID
+    
+    init(
+        questionID: QuestionID
+    ) {
+        self.questionID = questionID
+    }
+}

--- a/DoriDori_iOS/DoriDori_iOS/Common/APIs/ReportController/ReportRequest.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Common/APIs/ReportController/ReportRequest.swift
@@ -1,0 +1,32 @@
+//
+//  ReportRequest.swift
+//  DoriDori_iOS
+//
+//  Created by Seori on 2022/09/18.
+//
+
+import Foundation
+
+enum ReportType {
+    case post
+    case question
+    case answer
+    case comment
+}
+
+struct ReportRequest: Requestable {
+    var path: String { "/api/v1/report/\(type)/\(targetID)" }
+    var parameters: Parameter? { nil }
+    var method: HTTPMethod { .post }
+    private let type: ReportType
+    private let targetID: String
+    
+    
+    init(
+        type: ReportType,
+        targetID: String
+    ) {
+        self.type = type
+        self.targetID = targetID
+    }
+}

--- a/DoriDori_iOS/DoriDori_iOS/Common/APIs/UserController/BlockUserRequest.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Common/APIs/UserController/BlockUserRequest.swift
@@ -1,0 +1,21 @@
+//
+//  BlockUserRequest.swift
+//  DoriDori_iOS
+//
+//  Created by Seori on 2022/09/26.
+//
+
+import Foundation
+
+struct BlockUserRequest: Requestable {
+    var path: String { "/api/v1/user/block/\(self.userID)"}
+    var parameters: Parameter? { nil }
+    var method: HTTPMethod { .post }
+    private let userID: UserID
+    
+    init(
+        userID: UserID
+    ) {
+        self.userID = userID
+    }
+}

--- a/DoriDori_iOS/DoriDori_iOS/Scene/Common/ActionSheet/ActionSheetAlertController.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/Common/ActionSheet/ActionSheetAlertController.swift
@@ -40,6 +40,20 @@ final class ActionSheetAlertController {
         self.tintColor = tintColor
     }
     
+    init(
+        title: String? = nil,
+        message: String? = nil,
+        actionModels: [ActionSheetAction],
+        neededCancel: Bool = true,
+        tintColor: UIColor = .lime300
+    ) {
+        self.title = title
+        self.message = message
+        self.actionModels = actionModels
+        self.neededCancel = neededCancel
+        self.tintColor = tintColor
+    }
+    
     func configure() -> UIAlertController {
         let alertController = UIAlertController(
             title: title,

--- a/DoriDori_iOS/DoriDori_iOS/Scene/Common/ActionSheet/ActionSheetAlertController.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/Common/ActionSheet/ActionSheetAlertController.swift
@@ -1,0 +1,64 @@
+//
+//  ActionSheetAlertController.swift
+//  DoriDori_iOS
+//
+//  Created by Seori on 2022/08/17.
+//
+import UIKit
+
+struct ActionSheetAction {
+    let title: String
+    let action: ((UIAlertAction) -> Void)?
+    
+    init(
+        title: String,
+        action: ((UIAlertAction) -> Void)?) {
+        self.title = title
+        self.action = action
+    }
+}
+
+final class ActionSheetAlertController {
+    
+    private let title: String?
+    private let message: String?
+    private let actionModels: [ActionSheetAction]
+    private let neededCancel: Bool
+    private let tintColor: UIColor
+    
+    init(
+        title: String? = nil,
+        message: String? = nil,
+        actionModels: ActionSheetAction...,
+        neededCancel: Bool = true,
+        tintColor: UIColor = .lime300
+    ) {
+        self.title = title
+        self.message = message
+        self.actionModels = actionModels
+        self.neededCancel = neededCancel
+        self.tintColor = tintColor
+    }
+    
+    func configure() -> UIAlertController {
+        let alertController = UIAlertController(
+            title: title,
+            message: message,
+            preferredStyle: .actionSheet
+        )
+        self.actionModels.forEach { actionModel in
+            alertController.addAction(
+                UIAlertAction(
+                    title: actionModel.title,
+                    style: .default,
+                    handler: actionModel.action
+                )
+            )
+        }
+        if self.neededCancel {
+            alertController.addAction(UIAlertAction(title: "취소", style: .cancel))
+        }
+        alertController.view.tintColor = self.tintColor
+        return alertController
+    }
+}

--- a/DoriDori_iOS/DoriDori_iOS/Scene/Common/SpeechBubble/MySpeechBubbleView/HomeMySpeechBubbleView.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/Common/SpeechBubble/MySpeechBubbleView/HomeMySpeechBubbleView.swift
@@ -11,7 +11,7 @@ import RxSwift
 
 protocol HomeSpeechBubleViewDelegate: AnyObject {
     func likeButtonDidTap(id: String, userLiked: Bool)
-    func commentButtonDidTap(postId: String, isMyPost: Bool)
+    func commentButtonDidTap(postId: String, postUserID: UserID)
     func shareButtonDidTap()
 }
 
@@ -202,9 +202,8 @@ extension HomeMySpeechBubbleView {
         commentButton.rx.tap
             .withUnretained(self)
             .subscribe(onNext: { owner, _ in
-                guard let info = owner.homeSpeechInfo,
-                      let userID = UserDefaults.userID else { return }
-                owner.delegate?.commentButtonDidTap(postId: info.id, isMyPost: userID == info.user.id)
+                guard let info = owner.homeSpeechInfo else { return }
+                owner.delegate?.commentButtonDidTap(postId: info.id, postUserID: info.user.id)
             })
             .disposed(by: disposeBag)
         

--- a/DoriDori_iOS/DoriDori_iOS/Scene/Common/SpeechBubble/MySpeechBubbleView/HomeMySpeechBubbleView.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/Common/SpeechBubble/MySpeechBubbleView/HomeMySpeechBubbleView.swift
@@ -11,7 +11,7 @@ import RxSwift
 
 protocol HomeSpeechBubleViewDelegate: AnyObject {
     func likeButtonDidTap(id: String, userLiked: Bool)
-    func commentButtonDidTap(postId: String)
+    func commentButtonDidTap(postId: String, isMyPost: Bool)
     func shareButtonDidTap()
 }
 
@@ -202,8 +202,9 @@ extension HomeMySpeechBubbleView {
         commentButton.rx.tap
             .withUnretained(self)
             .subscribe(onNext: { owner, _ in
-                guard let info = owner.homeSpeechInfo else { return }
-                owner.delegate?.commentButtonDidTap(postId: info.id)
+                guard let info = owner.homeSpeechInfo,
+                      let userID = UserDefaults.userID else { return }
+                owner.delegate?.commentButtonDidTap(postId: info.id, isMyPost: userID == info.user.id)
             })
             .disposed(by: disposeBag)
         

--- a/DoriDori_iOS/DoriDori_iOS/Scene/Common/SpeechBubble/MySpeechBubbleView/MyPageMySpeechBubbleCell.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/Common/SpeechBubble/MySpeechBubbleView/MyPageMySpeechBubbleCell.swift
@@ -40,12 +40,15 @@ final class MyPageMySpeechBubbleCell: UICollectionViewCell {
     private let levelView = LevelView()
     private let speechBubble = MyPageMySpeechBubbleView()
     private var disposeBag: DisposeBag
+    private let didTapMoreButton: PublishRelay<Void>
     
     // MARK: - Init
     
     override init(frame: CGRect) {
+        self.didTapMoreButton = .init()
         self.disposeBag = .init()
         super.init(frame: frame)
+        self.speechBubble.delegate = self
         self.setupLayouts()
     }
     
@@ -66,11 +69,22 @@ final class MyPageMySpeechBubbleCell: UICollectionViewCell {
         self.levelView.configure(level: item.level)
     }
     
-    func bindAction(didTapProfile: PublishRelay<IndexPath>, at indexPath: IndexPath) {
+    func bindAction(
+        didTapProfile: PublishRelay<IndexPath>,
+        didTapMoreButton: PublishRelay<IndexPath>? = nil,
+        at indexPath: IndexPath
+    ) {
         self.profileImageView.rx.tapGesture()
             .when(.recognized)
             .map { _ in return indexPath }
             .bind(to: didTapProfile)
+            .disposed(by: self.disposeBag)
+        
+        self.didTapMoreButton
+            .map { indexPath }
+            .bind { indexPath in
+                didTapMoreButton?.accept(indexPath)
+            }
             .disposed(by: self.disposeBag)
     }
     
@@ -109,5 +123,14 @@ extension MyPageMySpeechBubbleCell {
             $0.top.equalTo(self.profileImageView.snp.bottom).offset(8)
             $0.centerX.equalTo(self.profileImageView.snp.centerX)
         }
+    }
+}
+
+// MARK: - MyPageMySpeechBubbleViewDelegate
+
+extension MyPageMySpeechBubbleCell: MyPageMySpeechBubbleViewDelegate {
+    
+    func didTapMore(_ speechBubbleView: MyPageMySpeechBubbleView) {
+        self.didTapMoreButton.accept(())
     }
 }

--- a/DoriDori_iOS/DoriDori_iOS/Scene/Common/SpeechBubble/MySpeechBubbleView/MyPageMySpeechBubbleCell.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/Common/SpeechBubble/MySpeechBubbleView/MyPageMySpeechBubbleCell.swift
@@ -70,14 +70,16 @@ final class MyPageMySpeechBubbleCell: UICollectionViewCell {
     }
     
     func bindAction(
-        didTapProfile: PublishRelay<IndexPath>,
+        didTapProfile: PublishRelay<IndexPath>? = nil,
         didTapMoreButton: PublishRelay<IndexPath>? = nil,
         at indexPath: IndexPath
     ) {
         self.profileImageView.rx.tapGesture()
             .when(.recognized)
             .map { _ in return indexPath }
-            .bind(to: didTapProfile)
+            .bind { indexPath in 
+                didTapProfile?.accept(indexPath)
+            }
             .disposed(by: self.disposeBag)
         
         self.didTapMoreButton

--- a/DoriDori_iOS/DoriDori_iOS/Scene/Common/SpeechBubble/MySpeechBubbleView/MyPageMySpeechBubbleView.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/Common/SpeechBubble/MySpeechBubbleView/MyPageMySpeechBubbleView.swift
@@ -6,6 +6,12 @@
 //
 
 import UIKit
+import RxSwift
+import RxCocoa
+
+protocol MyPageMySpeechBubbleViewDelegate: AnyObject {
+    func didTapMore(_ speechBubbleView: MyPageMySpeechBubbleView)
+}
 
 final class MyPageMySpeechBubbleView: MySpeechBubbleView,
                                       SpeechBubbleViewType,
@@ -93,7 +99,8 @@ final class MyPageMySpeechBubbleView: MySpeechBubbleView,
     }()
     
     // MARK: - Properties
-    
+    weak var delegate: MyPageMySpeechBubbleViewDelegate?
+    private let disposeBag: DisposeBag
     var likeButtonType: LikeButtonType { .heart }
     
     // MARK: - Init
@@ -103,12 +110,14 @@ final class MyPageMySpeechBubbleView: MySpeechBubbleView,
         borderColor: UIColor = .gray900,
         backgroundColor: UIColor = .gray900
     ) {
+        self.disposeBag = .init()
         super.init(
             borderWidth: borderWidth,
             borderColor: borderColor,
             backgroundColor: backgroundColor
         )
         self.setupLayouts()
+        self.bind()
     }
     
     required init?(coder: NSCoder) {
@@ -122,6 +131,17 @@ final class MyPageMySpeechBubbleView: MySpeechBubbleView,
         self.updatedTimeLabel.text = item.updatedTime
         self.setupContentLabel(item.content, at: self.contentLabel)
         self.setupLikeButton(item.likeCount, at: self.likeButton)
+    }
+}
+
+// MARK: - Private functions
+extension MyPageMySpeechBubbleView {
+    func bind() {
+        self.moreButton.rx.throttleTap
+            .bind(with: self) { owner, _ in
+                owner.delegate?.didTapMore(self)
+            }
+            .disposed(by: self.disposeBag)
     }
 }
 

--- a/DoriDori_iOS/DoriDori_iOS/Scene/Common/SpeechBubble/MySpeechBubbleView/MyPageMySpeechBubbleView.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/Common/SpeechBubble/MySpeechBubbleView/MyPageMySpeechBubbleView.swift
@@ -19,7 +19,7 @@ final class MyPageMySpeechBubbleView: MySpeechBubbleView,
     
     // MARK: - UIComponent
     
-    private let questionerNameLabel: UILabel = {
+    private let userNameLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.setKRFont(weight: .medium, size: 13)
         label.textColor = UIColor.gray200
@@ -29,7 +29,7 @@ final class MyPageMySpeechBubbleView: MySpeechBubbleView,
         let bracketImageView = UIImageView(image: UIImage(named: "right_bracket"))
         return bracketImageView
     }()
-    private let userNameLabel: UILabel = {
+    private let questionerNameLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.setKRFont(weight: .medium, size: 13)
         label.textColor = UIColor.lime300
@@ -125,8 +125,8 @@ final class MyPageMySpeechBubbleView: MySpeechBubbleView,
     }
     
     func configure(_ item: MyPageMySpeechBubbleViewItemType) {
-        self.questionerNameLabel.text = item.questioner
         self.userNameLabel.text = item.userName
+        self.questionerNameLabel.text = item.questioner
         self.locationLabel.text = item.location
         self.updatedTimeLabel.text = item.updatedTime
         self.setupContentLabel(item.content, at: self.contentLabel)
@@ -151,9 +151,9 @@ extension MyPageMySpeechBubbleView {
     
     private func setupLayouts() {
         self.addSubViews(
-            self.questionerNameLabel,
-            self.bracketImageView,
             self.userNameLabel,
+            self.bracketImageView,
+            self.questionerNameLabel,
             self.moreButton,
             self.contentLabel,
             self.locationLabel,
@@ -165,13 +165,13 @@ extension MyPageMySpeechBubbleView {
         self.layoutsUserInfo()
         self.moreButton.snp.makeConstraints {
             $0.top.equalToSuperview().offset(15)
-            $0.leading.greaterThanOrEqualTo(self.userNameLabel.snp.trailing).offset(4)
+            $0.leading.greaterThanOrEqualTo(self.questionerNameLabel.snp.trailing).offset(4)
             $0.trailing.equalToSuperview().inset(18)
             $0.size.equalTo(24)
         }
         self.contentLabel.snp.makeConstraints {
-            $0.top.equalTo(self.questionerNameLabel.snp.bottom).offset(18)
-            $0.leading.equalTo(self.questionerNameLabel.snp.leading)
+            $0.top.equalTo(self.userNameLabel.snp.bottom).offset(18)
+            $0.leading.equalTo(self.userNameLabel.snp.leading)
             $0.trailing.equalToSuperview().inset(26)
         }
         self.layoutsLocationAndTime()
@@ -191,19 +191,19 @@ extension MyPageMySpeechBubbleView {
     
     private func layoutsUserInfo() {
         
-        self.questionerNameLabel.snp.makeConstraints {
+        self.userNameLabel.snp.makeConstraints {
             $0.height.equalTo(18)
             $0.leading.equalToSuperview().offset(18)
             $0.top.equalToSuperview().offset(18)
         }
         self.bracketImageView.snp.makeConstraints {
-            $0.leading.equalTo(self.questionerNameLabel.snp.trailing).offset(8)
-            $0.centerY.equalTo(self.questionerNameLabel.snp.centerY)
+            $0.leading.equalTo(self.userNameLabel.snp.trailing).offset(8)
+            $0.centerY.equalTo(self.userNameLabel.snp.centerY)
             $0.width.equalTo(4)
             $0.height.equalTo(8)
         }
-        self.userNameLabel.snp.makeConstraints {
-            $0.top.equalTo(self.questionerNameLabel.snp.top)
+        self.questionerNameLabel.snp.makeConstraints {
+            $0.top.equalTo(self.userNameLabel.snp.top)
             $0.leading.equalTo(self.bracketImageView.snp.trailing).offset(8)
             $0.height.equalTo(18)
         }

--- a/DoriDori_iOS/DoriDori_iOS/Scene/Common/SpeechBubble/OtherSpeechBubbleView/HomeOtherSpeechBubbleView.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/Common/SpeechBubble/OtherSpeechBubbleView/HomeOtherSpeechBubbleView.swift
@@ -281,9 +281,8 @@ extension HomeOtherSpeechBubbleView {
         commentButton.rx.tap
             .withUnretained(self)
             .subscribe(onNext: { owner, _ in
-                guard let info = owner.homeSpeechInfo,
-                      let userID = UserDefaults.userID else { return }
-                owner.delegate?.commentButtonDidTap(postId: info.id, isMyPost: userID == info.user.id)
+                guard let info = owner.homeSpeechInfo else { return }
+                owner.delegate?.commentButtonDidTap(postId: info.id, postUserID: info.user.id)
             })
             .disposed(by: disposeBag)
         

--- a/DoriDori_iOS/DoriDori_iOS/Scene/Common/SpeechBubble/OtherSpeechBubbleView/HomeOtherSpeechBubbleView.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/Common/SpeechBubble/OtherSpeechBubbleView/HomeOtherSpeechBubbleView.swift
@@ -281,8 +281,9 @@ extension HomeOtherSpeechBubbleView {
         commentButton.rx.tap
             .withUnretained(self)
             .subscribe(onNext: { owner, _ in
-                guard let info = owner.homeSpeechInfo else { return }
-                owner.delegate?.commentButtonDidTap(postId: info.id)
+                guard let info = owner.homeSpeechInfo,
+                      let userID = UserDefaults.userID else { return }
+                owner.delegate?.commentButtonDidTap(postId: info.id, isMyPost: userID == info.user.id)
             })
             .disposed(by: disposeBag)
         

--- a/DoriDori_iOS/DoriDori_iOS/Scene/Common/SpeechBubble/OtherSpeechBubbleView/MyPageOtherSpeechBubbleCell.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/Common/SpeechBubble/OtherSpeechBubbleView/MyPageOtherSpeechBubbleCell.swift
@@ -58,6 +58,7 @@ final class MyPageOtherSpeechBubbleCell: UICollectionViewCell {
     private lazy var speechBubble = MyPageOtherSpeechBubbleView(delegate: self)
     private let didTapComment: PublishRelay<Void>
     private let didTapDeny: PublishRelay<Void>
+    private let didTapMoreButton: PublishRelay<Void>
     private var disposeBag = DisposeBag()
     
     // MARK: Init
@@ -65,6 +66,7 @@ final class MyPageOtherSpeechBubbleCell: UICollectionViewCell {
     override init(frame: CGRect) {
         self.didTapComment = .init()
         self.didTapDeny = .init()
+        self.didTapMoreButton = .init()
         super.init(frame: frame)
         self.setupLayouts()
     }
@@ -93,6 +95,7 @@ final class MyPageOtherSpeechBubbleCell: UICollectionViewCell {
         didTapProfile: PublishRelay<IndexPath>,
         didTapComment: PublishRelay<IndexPath>? = nil,
         didTapDeny: PublishRelay<IndexPath>? = nil,
+        didTapMoreButton: PublishRelay<IndexPath>? = nil,
         at indexPath: IndexPath
     ) {
         self.profileImageView.rx.tapGesture()
@@ -113,6 +116,13 @@ final class MyPageOtherSpeechBubbleCell: UICollectionViewCell {
             .bind(onNext: { indexPath in
                 didTapComment?.accept(indexPath)
             })
+            .disposed(by: self.disposeBag)
+        
+        self.didTapMoreButton
+            .map { indexPath }
+            .bind { indexPath in
+                didTapMoreButton?.accept(indexPath)
+            }
             .disposed(by: self.disposeBag)
     }
     
@@ -160,5 +170,9 @@ extension MyPageOtherSpeechBubbleCell: MyPageOtherSpeechBubbleViewDelegate {
     
     func didTapComment(_ speechBubbleView: MyPageOtherSpeechBubbleView) {
         self.didTapComment.accept(())
+    }
+    
+    func didTapMore(_ speechBubbleView: MyPageOtherSpeechBubbleView) {
+        self.didTapMoreButton.accept(())
     }
 }

--- a/DoriDori_iOS/DoriDori_iOS/Scene/Common/SpeechBubble/OtherSpeechBubbleView/MyPageOtherSpeechBubbleView.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/Common/SpeechBubble/OtherSpeechBubbleView/MyPageOtherSpeechBubbleView.swift
@@ -11,6 +11,7 @@ import RxSwift
 protocol MyPageOtherSpeechBubbleViewDelegate: AnyObject {
     func didTapDeny(_ speechBubbleView: MyPageOtherSpeechBubbleView)
     func didTapComment(_ speechBubbleView: MyPageOtherSpeechBubbleView)
+    func didTapMore(_ speechBubbleView: MyPageOtherSpeechBubbleView)
 }
 
 final class MyPageOtherSpeechBubbleView: OtherSpeechBubbleView,
@@ -171,6 +172,12 @@ extension MyPageOtherSpeechBubbleView {
         self.denyButton.rx.throttleTap
             .bind(with: self) { owner, _ in
                 owner.delegate?.didTapDeny(owner)
+            }
+            .disposed(by: self.disposeBag)
+        
+        self.moreButton.rx.throttleTap
+            .bind(with: self) { owner, _ in
+                owner.delegate?.didTapMore(owner)
             }
             .disposed(by: self.disposeBag)
     }

--- a/DoriDori_iOS/DoriDori_iOS/Scene/Home/HomeCoordinator.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/Home/HomeCoordinator.swift
@@ -23,10 +23,10 @@ final class HomeCoordinator: HomeCoordinatorPresentable {
     }
     
     func navigateToQuestionDetail(postId: String) {
-        WebViewCoordinator(
-            navigationController: self.navigationController,
-            type: .questionDetail(id: postId),
-            navigateStyle: .push
-        ).start()
+//        WebViewCoordinator(
+//            navigationController: self.navigationController,
+//            type: .questionDetail(id: postId),
+//            navigateStyle: .push
+//        ).start()
     }
 }

--- a/DoriDori_iOS/DoriDori_iOS/Scene/Home/View/HomeCollectionViewImplement.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/Home/View/HomeCollectionViewImplement.swift
@@ -80,8 +80,8 @@ extension HomeCollectionViewImplement: HomeSpeechBubleViewDelegate {
         }
     }
     
-    func commentButtonDidTap(postId: String) {
-        WebViewCoordinator(navigationController: navigationController, type: .postDetail(id: postId), navigateStyle: .push)
+    func commentButtonDidTap(postId: String, isMyPost: Bool) {
+        WebViewCoordinator(navigationController: navigationController, type: .postDetail(id: postId, isMyPost: isMyPost), navigateStyle: .push)
             .start()
     }
     

--- a/DoriDori_iOS/DoriDori_iOS/Scene/Home/View/HomeCollectionViewImplement.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/Home/View/HomeCollectionViewImplement.swift
@@ -80,8 +80,8 @@ extension HomeCollectionViewImplement: HomeSpeechBubleViewDelegate {
         }
     }
     
-    func commentButtonDidTap(postId: String, isMyPost: Bool) {
-        WebViewCoordinator(navigationController: navigationController, type: .postDetail(id: postId, isMyPost: isMyPost), navigateStyle: .push)
+    func commentButtonDidTap(postId: String, postUserID: UserID) {
+        WebViewCoordinator(navigationController: navigationController, type: .postDetail(id: postId, postUserID: postUserID), navigateStyle: .push)
             .start()
     }
     

--- a/DoriDori_iOS/DoriDori_iOS/Scene/Home/View/HomeCollectionViewImplement.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/Home/View/HomeCollectionViewImplement.swift
@@ -81,7 +81,7 @@ extension HomeCollectionViewImplement: HomeSpeechBubleViewDelegate {
     }
     
     func commentButtonDidTap(postId: String) {
-        WebViewCoordinator(navigationController: navigationController, type: .questionDetail(id: postId), navigateStyle: .push)
+        WebViewCoordinator(navigationController: navigationController, type: .postDetail(id: postId), navigateStyle: .push)
             .start()
     }
     

--- a/DoriDori_iOS/DoriDori_iOS/Scene/MyPage/AnswerComplete/AnswerCompleteReactor.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/MyPage/AnswerComplete/AnswerCompleteReactor.swift
@@ -24,7 +24,7 @@ final class AnswerCompleteReactor: Reactor {
     
     enum Mutation {
         case questionAndAnswers([MyPageBubbleItemType])
-        case didSelect(questionID: QuestionID, isMyQuestion: Bool)
+        case didSelect(questionID: QuestionID, questionUserID: UserID)
         case didTap(UserID)
         case endRefreshing([MyPageBubbleItemType])
         case didTapReport(ActionSheetAlertController)
@@ -33,7 +33,7 @@ final class AnswerCompleteReactor: Reactor {
     
     struct State {
         @Pulse var questionAndAnswer: [MyPageBubbleItemType] = []
-        @Pulse var navigateQuestionID: (questionID: QuestionID, isMyQuestion: Bool)?
+        @Pulse var navigateQuestionID: (questionID: QuestionID, questionUserID: UserID)?
         @Pulse var navigateUserID: UserID?
         @Pulse var endRefreshing: Bool?
         @Pulse var actionSheetAlertController: ActionSheetAlertController?
@@ -87,10 +87,10 @@ final class AnswerCompleteReactor: Reactor {
             guard let question = self.currentState.questionAndAnswer[safe: indexPath.item] ,
                   let userID = UserDefaults.userID else { return .empty() }
             if let myAnswer = question as? MyPageMySpeechBubbleCellItem {
-                return .just(.didSelect(questionID: myAnswer.questionID, isMyQuestion: userID == myAnswer.userID))
+                return .just(.didSelect(questionID: myAnswer.questionID, questionUserID: myAnswer.userID))
             }
             if let question = question as? MyPageOtherSpeechBubbleItemType {
-                return .just(.didSelect(questionID: question.questionID, isMyQuestion: userID == question.userID))
+                return .just(.didSelect(questionID: question.questionID, questionUserID: question.userID))
             }
             return .empty()
             
@@ -242,8 +242,8 @@ final class AnswerCompleteReactor: Reactor {
             } else {
                 _state.questionAndAnswer.append(contentsOf: questions)
             }
-        case .didSelect(let questionID, let isMyQuestion):
-            _state.navigateQuestionID = (questionID, isMyQuestion)
+        case .didSelect(let questionID, let questionUserID):
+            _state.navigateQuestionID = (questionID, questionUserID)
         case .didTap(let userID):
             _state.navigateUserID = userID
         case .endRefreshing(let questionAndAnswer):

--- a/DoriDori_iOS/DoriDori_iOS/Scene/MyPage/AnswerComplete/AnswerCompleteViewController.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/MyPage/AnswerComplete/AnswerCompleteViewController.swift
@@ -110,7 +110,7 @@ final class AnswerCompleteViewController: UIViewController,
         reactor.pulse(\.$navigateQuestionID)
             .compactMap { $0 }
             .bind(with: self) { owner, value in
-                owner.coordinator.navigateToQuestionDetail(questionID: value.questionID, isMyQuestion: value.isMyQuestion)
+                owner.coordinator.navigateToQuestionDetail(questionID: value.questionID, questionUserID: value.questionUserID)
             }
             .disposed(by: self.disposeBag)
         

--- a/DoriDori_iOS/DoriDori_iOS/Scene/MyPage/AnswerComplete/AnswerCompleteViewController.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/MyPage/AnswerComplete/AnswerCompleteViewController.swift
@@ -109,8 +109,8 @@ final class AnswerCompleteViewController: UIViewController,
         
         reactor.pulse(\.$navigateQuestionID)
             .compactMap { $0 }
-            .bind(with: self) { owner, questionID in
-                owner.coordinator.navigateToQuestionDetail(questionID: questionID)
+            .bind(with: self) { owner, value in
+                owner.coordinator.navigateToQuestionDetail(questionID: value.questionID, isMyQuestion: value.isMyQuestion)
             }
             .disposed(by: self.disposeBag)
         

--- a/DoriDori_iOS/DoriDori_iOS/Scene/MyPage/AnswerComplete/AnswerCompleteViewController.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/MyPage/AnswerComplete/AnswerCompleteViewController.swift
@@ -28,6 +28,7 @@ final class AnswerCompleteViewController: UIViewController,
     private let didTapProfile: PublishRelay<IndexPath>
     private let willDisplayCell: PublishRelay<IndexPath>
     private let didSelectCell: PublishRelay<IndexPath>
+    private let didTapMoreButton: PublishRelay<IndexPath>
     
     // MARK: - LifeCycles
     
@@ -45,6 +46,7 @@ final class AnswerCompleteViewController: UIViewController,
         coordinator: MyPageCoordinatable,
         reactor: AnswerCompleteReactor
     ) {
+        self.didTapMoreButton = .init()
         self.didSelectCell = .init()
         self.willDisplayCell = .init()
         self.reactor = reactor
@@ -89,6 +91,11 @@ final class AnswerCompleteViewController: UIViewController,
             .bind(to: reactor.action)
             .disposed(by: self.disposeBag)
         
+        self.didTapMoreButton
+            .map { AnswerCompleteReactor.Action.didTapReport($0) }
+            .bind(to: reactor.action)
+            .disposed(by: self.disposeBag)
+        
         reactor.pulse(\.$questionAndAnswer)
             .bind(to: questionItems)
             .disposed(by: self.disposeBag)
@@ -113,6 +120,23 @@ final class AnswerCompleteViewController: UIViewController,
             .observe(on: MainScheduler.instance)
             .bind(with: self) { owner, _ in
                 owner.refreshControl.endRefreshing()
+            }
+            .disposed(by: self.disposeBag)
+        
+        reactor.pulse(\.$actionSheetAlertController)
+            .compactMap { $0 }
+            .observe(on: MainScheduler.instance)
+            .bind(with: self) { owner, actionSheetController in
+                let actionSheet = actionSheetController.configure()
+                owner.present(actionSheet, animated: true)
+            }
+            .disposed(by: self.disposeBag)
+        
+        reactor.pulse(\.$showToast)
+            .compactMap { $0 }
+            .observe(on: MainScheduler.instance)
+            .bind(with: self) { owner, text in
+                DoriDoriToastView(text: text).show()
             }
             .disposed(by: self.disposeBag)
     }
@@ -168,14 +192,22 @@ extension AnswerCompleteViewController: UICollectionViewDataSource {
         if let otherSpeechBubbleItem = item as? MyPageOtherSpeechBubbleItemType {
             let cell = collectionView.dequeueReusableCell(type: MyPageOtherSpeechBubbleCell.self, for: indexPath)
             cell.configure(otherSpeechBubbleItem)
-            cell.bindAction(didTapProfile: self.didTapProfile, at: indexPath)
+            cell.bindAction(
+                didTapProfile: self.didTapProfile,
+                didTapMoreButton: self.didTapMoreButton,
+                at: indexPath
+            )
             return cell
         }
         
         if let mySpeechBubbleItem = item as? MyPageMySpeechBubbleCellItem {
             let cell = collectionView.dequeueReusableCell(type: MyPageMySpeechBubbleCell.self, for: indexPath)
             cell.configure(mySpeechBubbleItem)
-            cell.bindAction(didTapProfile: self.didTapProfile, at: indexPath)
+            cell.bindAction(
+                didTapProfile: self.didTapProfile,
+                didTapMoreButton: self.didTapMoreButton,
+                at: indexPath
+            )
             return cell
         }
         fatalError("can not casting itemtype")

--- a/DoriDori_iOS/DoriDori_iOS/Scene/MyPage/MyPageCoordinator.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/MyPage/MyPageCoordinator.swift
@@ -10,7 +10,7 @@ import UIKit
 protocol MyPageCoordinatable: Coordinator {
     func navigateToSetting()
     func navigateToShare()
-    func navigateToQuestionDetail(questionID: QuestionID)
+    func navigateToQuestionDetail(questionID: QuestionID, isMyQuestion: Bool)
     func navigateToOtherPage(userID: UserID)
 }
 
@@ -45,10 +45,10 @@ final class MyPageCoordinator: MyPageCoordinatable {
         ).start()
     }
     
-    func navigateToQuestionDetail(questionID: QuestionID) {
+    func navigateToQuestionDetail(questionID: QuestionID, isMyQuestion: Bool) {
         WebViewCoordinator(
             navigationController: self.navigationController,
-            type: .questionDetail(id: questionID),
+            type: .questionDetail(id: questionID, isMyQuestion: isMyQuestion),
             navigateStyle: .push
         ).start()
     }

--- a/DoriDori_iOS/DoriDori_iOS/Scene/MyPage/MyPageCoordinator.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/MyPage/MyPageCoordinator.swift
@@ -10,7 +10,7 @@ import UIKit
 protocol MyPageCoordinatable: Coordinator {
     func navigateToSetting()
     func navigateToShare()
-    func navigateToQuestionDetail(questionID: QuestionID, isMyQuestion: Bool)
+    func navigateToQuestionDetail(questionID: QuestionID, questionUserID: UserID)
     func navigateToOtherPage(userID: UserID)
 }
 
@@ -45,10 +45,10 @@ final class MyPageCoordinator: MyPageCoordinatable {
         ).start()
     }
     
-    func navigateToQuestionDetail(questionID: QuestionID, isMyQuestion: Bool) {
+    func navigateToQuestionDetail(questionID: QuestionID, questionUserID: UserID) {
         WebViewCoordinator(
             navigationController: self.navigationController,
-            type: .questionDetail(id: questionID, isMyQuestion: isMyQuestion),
+            type: .questionDetail(id: questionID, questionUserID: questionUserID),
             navigateStyle: .push
         ).start()
     }

--- a/DoriDori_iOS/DoriDori_iOS/Scene/MyPage/MyPageRepository.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/MyPage/MyPageRepository.swift
@@ -15,6 +15,8 @@ protocol MyPageRequestable: AnyObject {
     func fetchReceivedQuestions(size: Int, lastQuestionID: QuestionID?) -> Observable<ReceivedQuestionModel>
     func denyQuestion(questionID: QuestionID) -> Observable<String>
     func postComment(to questionID: QuestionID, content: String, location: Location) -> Observable<String>
+    
+    func requestReport(type: ReportType, targetID: String) -> Observable<Bool>
 }
 
 final class MyPageRepository: MyPageRequestable {
@@ -59,6 +61,12 @@ final class MyPageRepository: MyPageRequestable {
                 location: location
             ),
             responseModel: ResponseModel<String>.self
+        )
+    }
+    func requestReport(type: ReportType, targetID: String) -> Observable<Bool> {
+        Network().request(
+            api: ReportRequest(type: type, targetID: targetID),
+            responseModel: ResponseModel<Bool>.self
         )
     }
 }

--- a/DoriDori_iOS/DoriDori_iOS/Scene/MyPage/QuestionReceived/QuestionReceivedReactor.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/MyPage/QuestionReceived/QuestionReceivedReactor.swift
@@ -26,7 +26,7 @@ final class QuestionReceivedReactor: Reactor {
     enum Mutation {
         case questions([MyPageOtherSpeechBubbleItemType])
         case didTapProfile(UserID)
-        case didSelectQuestion(questionID: QuestionID, isMyQuestion: Bool)
+        case didSelectQuestion(questionID: QuestionID, questionUserID: UserID)
         case alert(AlertModel)
         case shouldDismissPresentedViewController
         case endRefreshing([MyPageOtherSpeechBubbleItemType])
@@ -37,7 +37,7 @@ final class QuestionReceivedReactor: Reactor {
     
     struct State {
         @Pulse var receivedQuestions: [MyPageOtherSpeechBubbleItemType] = []
-        @Pulse var navigateQuestionID: (questionID: QuestionID, isMyQuestion: Bool)?
+        @Pulse var navigateQuestionID: (questionID: QuestionID, questionUserID: UserID)?
         @Pulse var navigateUserID: UserID?
         @Pulse var alert: AlertModel?
         @Pulse var shouldDismissPresentedViewController: Void?
@@ -196,9 +196,8 @@ final class QuestionReceivedReactor: Reactor {
             }
             
         case .didSelectCell(let indexPath):
-            guard let question = self.question(at: indexPath),
-                  let userID = UserDefaults.userID else { return .empty() }
-            return .just(.didSelectQuestion(questionID: question.questionID, isMyQuestion: question.userID == userID))
+            guard let question = self.question(at: indexPath) else { return .empty() }
+            return .just(.didSelectQuestion(questionID: question.questionID, questionUserID: question.userID))
             
         case .didRefresh:
             self.lastQuestionID = nil
@@ -231,8 +230,8 @@ final class QuestionReceivedReactor: Reactor {
             _state.receivedQuestions = questions
         case .didTapProfile(let userID):
             _state.navigateUserID = userID
-        case .didSelectQuestion(let questionID, let isMyQuestion):
-            _state.navigateQuestionID = (questionID, isMyQuestion)
+        case .didSelectQuestion(let questionID, let questionUserID):
+            _state.navigateQuestionID = (questionID, questionUserID)
         case .alert(let alertModel):
             _state.alert = alertModel
         case .shouldDismissPresentedViewController:

--- a/DoriDori_iOS/DoriDori_iOS/Scene/MyPage/QuestionReceived/QuestionReceivedReactor.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/MyPage/QuestionReceived/QuestionReceivedReactor.swift
@@ -26,7 +26,7 @@ final class QuestionReceivedReactor: Reactor {
     enum Mutation {
         case questions([MyPageOtherSpeechBubbleItemType])
         case didTapProfile(UserID)
-        case didSelectQuestion(QuestionID)
+        case didSelectQuestion(questionID: QuestionID, isMyQuestion: Bool)
         case alert(AlertModel)
         case shouldDismissPresentedViewController
         case endRefreshing([MyPageOtherSpeechBubbleItemType])
@@ -37,7 +37,7 @@ final class QuestionReceivedReactor: Reactor {
     
     struct State {
         @Pulse var receivedQuestions: [MyPageOtherSpeechBubbleItemType] = []
-        @Pulse var navigateQuestionID: QuestionID?
+        @Pulse var navigateQuestionID: (questionID: QuestionID, isMyQuestion: Bool)?
         @Pulse var navigateUserID: UserID?
         @Pulse var alert: AlertModel?
         @Pulse var shouldDismissPresentedViewController: Void?
@@ -196,8 +196,9 @@ final class QuestionReceivedReactor: Reactor {
             }
             
         case .didSelectCell(let indexPath):
-            guard let question = self.question(at: indexPath) else { return .empty() }
-            return .just(.didSelectQuestion(question.questionID))
+            guard let question = self.question(at: indexPath),
+                  let userID = UserDefaults.userID else { return .empty() }
+            return .just(.didSelectQuestion(questionID: question.questionID, isMyQuestion: question.userID == userID))
             
         case .didRefresh:
             self.lastQuestionID = nil
@@ -230,8 +231,8 @@ final class QuestionReceivedReactor: Reactor {
             _state.receivedQuestions = questions
         case .didTapProfile(let userID):
             _state.navigateUserID = userID
-        case .didSelectQuestion(let questionID):
-            _state.navigateQuestionID = questionID
+        case .didSelectQuestion(let questionID, let isMyQuestion):
+            _state.navigateQuestionID = (questionID, isMyQuestion)
         case .alert(let alertModel):
             _state.alert = alertModel
         case .shouldDismissPresentedViewController:

--- a/DoriDori_iOS/DoriDori_iOS/Scene/MyPage/QuestionReceived/QuestionReceivedViewController.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/MyPage/QuestionReceived/QuestionReceivedViewController.swift
@@ -190,8 +190,8 @@ final class QuestionReceivedViewController: UIViewController,
         
         reactor.pulse(\.$navigateQuestionID)
             .compactMap { $0 }
-            .bind(with: self) { owner, questionID in
-                owner.coordiantor.navigateToQuestionDetail(questionID: questionID)
+            .bind(with: self) { owner, value in
+                owner.coordiantor.navigateToQuestionDetail(questionID: value.questionID, isMyQuestion: value.isMyQuestion)
             }
             .disposed(by: self.disposeBag)
         

--- a/DoriDori_iOS/DoriDori_iOS/Scene/MyPage/QuestionReceived/QuestionReceivedViewController.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/MyPage/QuestionReceived/QuestionReceivedViewController.swift
@@ -54,6 +54,7 @@ final class QuestionReceivedViewController: UIViewController,
     private let questions: BehaviorRelay<[MyPageOtherSpeechBubbleItemType]>
     private let didTapProfile: PublishRelay<IndexPath>
     private let didTapDenyButton: PublishRelay<IndexPath>
+    private let didTapMoreButton: PublishRelay<IndexPath>
     private let didTapCommentButton: PublishRelay<IndexPath>
     private let didSelectCell: PublishRelay<IndexPath>
     private let willDisplayCell: PublishRelay<IndexPath>
@@ -64,6 +65,7 @@ final class QuestionReceivedViewController: UIViewController,
         reactor: QuestionReceivedReactor,
         coordiantor: MyPageCoordinatable
     ) {
+        self.didTapMoreButton = .init()
         self.didTapRegistButton = .init()
         self.willDisplayCell = .init()
         self.didSelectCell = .init()
@@ -123,6 +125,11 @@ final class QuestionReceivedViewController: UIViewController,
         
         self.didTapProfile
             .map { QuestionReceivedReactor.Action.didTapProfile($0) }
+            .bind(to: reactor.action)
+            .disposed(by: self.disposeBag)
+        
+        self.didTapMoreButton
+            .map { QuestionReceivedReactor.Action.didTapReport($0) }
             .bind(to: reactor.action)
             .disposed(by: self.disposeBag)
         
@@ -220,6 +227,15 @@ final class QuestionReceivedViewController: UIViewController,
                 DoriDoriToastView(text: toast).show()
             }
             .disposed(by: self.disposeBag)
+        
+        reactor.pulse(\.$actionSheetAlertController)
+            .compactMap { $0 }
+            .observe(on: MainScheduler.instance)
+            .bind(with: self) { owner, actionSheet in
+                let viewController = actionSheet.configure()
+                owner.present(viewController, animated: true)
+            }
+            .disposed(by: self.disposeBag)
     }
     
     private func bind() {
@@ -301,6 +317,7 @@ extension QuestionReceivedViewController: UICollectionViewDataSource {
             didTapProfile: self.didTapProfile,
             didTapComment: self.didTapCommentButton,
             didTapDeny: self.didTapDenyButton,
+            didTapMoreButton: self.didTapMoreButton,
             at: indexPath
         )
         return cell

--- a/DoriDori_iOS/DoriDori_iOS/Scene/MyPage/QuestionReceived/QuestionReceivedViewController.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/MyPage/QuestionReceived/QuestionReceivedViewController.swift
@@ -191,7 +191,7 @@ final class QuestionReceivedViewController: UIViewController,
         reactor.pulse(\.$navigateQuestionID)
             .compactMap { $0 }
             .bind(with: self) { owner, value in
-                owner.coordiantor.navigateToQuestionDetail(questionID: value.questionID, isMyQuestion: value.isMyQuestion)
+                owner.coordiantor.navigateToQuestionDetail(questionID: value.questionID, questionUserID: value.questionUserID)
             }
             .disposed(by: self.disposeBag)
         

--- a/DoriDori_iOS/DoriDori_iOS/Scene/OtherPage/OtherPageCoordinator.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/OtherPage/OtherPageCoordinator.swift
@@ -10,7 +10,7 @@ import UIKit
 
 protocol OtherPageCoordinatable: Coordinator {
     func pop()
-    func navigateToQuestionDetail(questionID: QuestionID, isMyQuestion: Bool)
+    func navigateToQuestionDetail(questionID: QuestionID, questionUserID: UserID)
     func navigateToOtherPage(userID: UserID)
     func navigateToProfileShare()
     func navigateToQuestion()
@@ -48,10 +48,10 @@ final class OtherPageCoordinator: OtherPageCoordinatable {
         self.navigationController.popViewController(animated: true)
     }
     
-    func navigateToQuestionDetail(questionID: QuestionID, isMyQuestion: Bool) {
+    func navigateToQuestionDetail(questionID: QuestionID, questionUserID: UserID) {
         WebViewCoordinator(
             navigationController: self.navigationController,
-            type: .questionDetail(id: questionID, isMyQuestion: isMyQuestion),
+            type: .questionDetail(id: questionID, questionUserID: questionUserID),
             navigateStyle: .push
         ).start()
     }

--- a/DoriDori_iOS/DoriDori_iOS/Scene/OtherPage/OtherPageCoordinator.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/OtherPage/OtherPageCoordinator.swift
@@ -10,7 +10,7 @@ import UIKit
 
 protocol OtherPageCoordinatable: Coordinator {
     func pop()
-    func navigateToQuestionDetail(questionID: QuestionID)
+    func navigateToQuestionDetail(questionID: QuestionID, isMyQuestion: Bool)
     func navigateToOtherPage(userID: UserID)
     func navigateToProfileShare()
     func navigateToQuestion()
@@ -48,10 +48,10 @@ final class OtherPageCoordinator: OtherPageCoordinatable {
         self.navigationController.popViewController(animated: true)
     }
     
-    func navigateToQuestionDetail(questionID: QuestionID) {
+    func navigateToQuestionDetail(questionID: QuestionID, isMyQuestion: Bool) {
         WebViewCoordinator(
             navigationController: self.navigationController,
-            type: .questionDetail(id: questionID),
+            type: .questionDetail(id: questionID, isMyQuestion: isMyQuestion),
             navigateStyle: .push
         ).start()
     }

--- a/DoriDori_iOS/DoriDori_iOS/Scene/OtherPage/OtherPageRepository.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/OtherPage/OtherPageRepository.swift
@@ -11,6 +11,7 @@ import RxSwift
 protocol OtherPageRequestable: AnyObject {
     func fetchOtherProfile(userID: UserID) -> Observable<UserInfoModel>
     func fetchQuestionAndAnswer(size: Int, userID: UserID) -> Observable<AnswerCompleteModel>
+    func requestReport(type: ReportType, targetID: String) -> Observable<Bool>
 }
 
 final class OtherPageRepository: OtherPageRequestable {
@@ -29,6 +30,13 @@ final class OtherPageRepository: OtherPageRequestable {
                 size: size
             ),
             responseModel: ResponseModel<AnswerCompleteModel>.self
+        )
+    }
+    
+    func requestReport(type: ReportType, targetID: String) -> Observable<Bool> {
+        Network().request(
+            api: ReportRequest(type: type, targetID: targetID),
+            responseModel: ResponseModel<Bool>.self
         )
     }
 }

--- a/DoriDori_iOS/DoriDori_iOS/Scene/OtherPage/OtherProflieContent/OtherProfileContentReactor.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/OtherPage/OtherProflieContent/OtherProfileContentReactor.swift
@@ -23,7 +23,7 @@ final class OtherProfileContentReactor: Reactor {
     
     enum Mutation {
         case quetsions([MyPageBubbleItemType])
-        case didSelect(QuestionID)
+        case didSelect(questionID: QuestionID, isMyQuestion: Bool)
         case didTap(UserID)
         case didTapReport(ActionSheetAlertController)
         case toast(text: String)
@@ -31,7 +31,7 @@ final class OtherProfileContentReactor: Reactor {
     
     struct State {
         @Pulse var questionAndAnswer: [MyPageBubbleItemType] = []
-        @Pulse var navigateQuestionID: QuestionID?
+        @Pulse var navigateQuestionID: (questionID: QuestionID, isMyQuestion: Bool)?
         @Pulse var navigateUserID: UserID?
         @Pulse var actionSheetController: ActionSheetAlertController?
         @Pulse var toast: String?
@@ -143,12 +143,13 @@ final class OtherProfileContentReactor: Reactor {
             }
             
         case .didSelect(let indexPath):
-            guard let question = self.currentState.questionAndAnswer[safe: indexPath.item] else { return .empty() }
+            guard let question = self.currentState.questionAndAnswer[safe: indexPath.item],
+                  let userID = UserDefaults.userID else { return .empty() }
             if let myAnswer = question as? MyPageMySpeechBubbleCellItem {
-                return .just(.didSelect(myAnswer.questionID))
+                return .just(.didSelect(questionID: myAnswer.questionID, isMyQuestion: userID == myAnswer.userID))
             }
             if let question = question as? MyPageOtherSpeechBubbleItemType {
-                return .just(.didSelect(question.questionID))
+                return .just(.didSelect(questionID: question.questionID, isMyQuestion: userID == question.userID))
             }
             return .empty()
          
@@ -232,8 +233,8 @@ final class OtherProfileContentReactor: Reactor {
             } else {
                 _state.questionAndAnswer.append(contentsOf: questions)
             }
-        case .didSelect(let questionID):
-            _state.navigateQuestionID = questionID
+        case .didSelect(let questionID, let isMyQuestion):
+            _state.navigateQuestionID = (questionID, isMyQuestion)
         case .didTap(let userID):
             _state.navigateUserID = userID
         case .didTapReport(let actionSheetcontroller):

--- a/DoriDori_iOS/DoriDori_iOS/Scene/OtherPage/OtherProflieContent/OtherProfileContentReactor.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/OtherPage/OtherProflieContent/OtherProfileContentReactor.swift
@@ -13,7 +13,7 @@ import ReactorKit
 final class OtherProfileContentReactor: Reactor {
     
     enum Action {
-        case viewDidLoad
+        case fetchNewData
         case didSelect(IndexPath)
         case willDisplayCell(IndexPath)
         case didTapProfile(IndexPath)
@@ -127,7 +127,7 @@ final class OtherProfileContentReactor: Reactor {
     
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
-        case .viewDidLoad:
+        case .fetchNewData:
             return self.fetchQuestionAndAnswer(
                 userID: self.userID,
                 lastID: self.lastID

--- a/DoriDori_iOS/DoriDori_iOS/Scene/OtherPage/OtherProflieContent/OtherProfileContentReactor.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/OtherPage/OtherProflieContent/OtherProfileContentReactor.swift
@@ -23,7 +23,7 @@ final class OtherProfileContentReactor: Reactor {
     
     enum Mutation {
         case quetsions([MyPageBubbleItemType])
-        case didSelect(questionID: QuestionID, isMyQuestion: Bool)
+        case didSelect(questionID: QuestionID, questionUserID: UserID)
         case didTap(UserID)
         case didTapReport(ActionSheetAlertController)
         case toast(text: String)
@@ -31,7 +31,7 @@ final class OtherProfileContentReactor: Reactor {
     
     struct State {
         @Pulse var questionAndAnswer: [MyPageBubbleItemType] = []
-        @Pulse var navigateQuestionID: (questionID: QuestionID, isMyQuestion: Bool)?
+        @Pulse var navigateQuestionID: (questionID: QuestionID, questionUserID: UserID)?
         @Pulse var navigateUserID: UserID?
         @Pulse var actionSheetController: ActionSheetAlertController?
         @Pulse var toast: String?
@@ -143,13 +143,12 @@ final class OtherProfileContentReactor: Reactor {
             }
             
         case .didSelect(let indexPath):
-            guard let question = self.currentState.questionAndAnswer[safe: indexPath.item],
-                  let userID = UserDefaults.userID else { return .empty() }
+            guard let question = self.currentState.questionAndAnswer[safe: indexPath.item] else { return .empty() }
             if let myAnswer = question as? MyPageMySpeechBubbleCellItem {
-                return .just(.didSelect(questionID: myAnswer.questionID, isMyQuestion: userID == myAnswer.userID))
+                return .just(.didSelect(questionID: myAnswer.questionID, questionUserID: myAnswer.userID))
             }
             if let question = question as? MyPageOtherSpeechBubbleItemType {
-                return .just(.didSelect(questionID: question.questionID, isMyQuestion: userID == question.userID))
+                return .just(.didSelect(questionID: question.questionID, questionUserID: question.userID))
             }
             return .empty()
          
@@ -233,8 +232,8 @@ final class OtherProfileContentReactor: Reactor {
             } else {
                 _state.questionAndAnswer.append(contentsOf: questions)
             }
-        case .didSelect(let questionID, let isMyQuestion):
-            _state.navigateQuestionID = (questionID, isMyQuestion)
+        case .didSelect(let questionID, let questionUserID):
+            _state.navigateQuestionID = (questionID, questionUserID)
         case .didTap(let userID):
             _state.navigateUserID = userID
         case .didTapReport(let actionSheetcontroller):

--- a/DoriDori_iOS/DoriDori_iOS/Scene/OtherPage/OtherProflieContent/OtherProfileContentViewController.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/OtherPage/OtherProflieContent/OtherProfileContentViewController.swift
@@ -84,8 +84,8 @@ final class OtherProfileContentViewController: UIViewController,
         
         reactor.pulse(\.$navigateQuestionID)
             .compactMap { $0 }
-            .bind(with: self) { owner, questionID in
-                owner.coordinator.navigateToQuestionDetail(questionID: questionID)
+            .bind(with: self) { owner, value in
+                owner.coordinator.navigateToQuestionDetail(questionID: value.questionID, isMyQuestion: value.isMyQuestion)
             }
             .disposed(by: self.disposeBag)
         

--- a/DoriDori_iOS/DoriDori_iOS/Scene/OtherPage/OtherProflieContent/OtherProfileContentViewController.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/OtherPage/OtherProflieContent/OtherProfileContentViewController.swift
@@ -87,7 +87,7 @@ final class OtherProfileContentViewController: UIViewController,
         reactor.pulse(\.$navigateQuestionID)
             .compactMap { $0 }
             .bind(with: self) { owner, value in
-                owner.coordinator.navigateToQuestionDetail(questionID: value.questionID, isMyQuestion: value.isMyQuestion)
+                owner.coordinator.navigateToQuestionDetail(questionID: value.questionID, questionUserID: value.questionUserID)
             }
             .disposed(by: self.disposeBag)
         

--- a/DoriDori_iOS/DoriDori_iOS/Scene/OtherPage/OtherProflieContent/OtherProfileContentViewController.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/OtherPage/OtherProflieContent/OtherProfileContentViewController.swift
@@ -23,6 +23,7 @@ final class OtherProfileContentViewController: UIViewController,
     }()
     
     private let viewDidLoadStream: PublishRelay<Void>
+    private let viewWillAppearStream: PublishRelay<Void>
     private let didSelectItem: PublishRelay<IndexPath>
     private let cellWillDisplay: PublishRelay<IndexPath>
     private let reactor: OtherProfileContentReactor
@@ -36,6 +37,7 @@ final class OtherProfileContentViewController: UIViewController,
         reactor: OtherProfileContentReactor,
         coordinator: OtherPageCoordinatable
     ) {
+        self.viewWillAppearStream = .init()
         self.didTapMoreButton = .init()
         self.didTapProfile = .init()
         self.coordinator = coordinator
@@ -57,8 +59,8 @@ final class OtherProfileContentViewController: UIViewController,
     }
     
     func bind(reactor: OtherProfileContentReactor) {
-        self.viewDidLoadStream
-            .map { OtherProfileContentReactor.Action.viewDidLoad }
+        Observable.merge(self.viewDidLoadStream.asObservable(), self.viewWillAppearStream.asObservable())
+            .map { OtherProfileContentReactor.Action.fetchNewData }
             .bind(to: reactor.action)
             .disposed(by: self.disposeBag)
         
@@ -122,6 +124,11 @@ final class OtherProfileContentViewController: UIViewController,
         self.bind(reactor: self.reactor)
         
         self.viewDidLoadStream.accept(())
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.viewWillAppearStream.accept(())
     }
     
     private func configure(_ collectionView: UICollectionView) {

--- a/DoriDori_iOS/DoriDori_iOS/Scene/WebView/DoriDoriQuestionPostDetailMore.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/WebView/DoriDoriQuestionPostDetailMore.swift
@@ -11,6 +11,7 @@ enum DoriDoriQuestionPostDetailMore {
     case modify
     case delete
     case toAnonymous
+    case share
     case report
     case block
     
@@ -19,21 +20,9 @@ enum DoriDoriQuestionPostDetailMore {
         case .modify: return "수정하기"
         case .delete: return "삭제하기"
         case .toAnonymous: return "익명으로 변경"
+        case .share: return "공유하기"
         case .report: return "신고하기"
         case .block: return "글쓴이 차단하기"
-        }
-    }
-    
-    var action: ((String) -> Void) {
-        switch self {
-        case .modify:
-           return { targetID in
-                print(targetID, "수정하기")
-            }
-        default:
-            return { targetID in
-               print(targetID)
-            }
         }
     }
 }

--- a/DoriDori_iOS/DoriDori_iOS/Scene/WebView/DoriDoriQuestionPostDetailMore.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/WebView/DoriDoriQuestionPostDetailMore.swift
@@ -1,0 +1,39 @@
+//
+//  DoriDoriQuestionPostDetailMore.swift
+//  DoriDori_iOS
+//
+//  Created by Seori on 2022/09/26.
+//
+
+import Foundation
+
+enum DoriDoriQuestionPostDetailMore {
+    case modify
+    case delete
+    case toAnonymous
+    case report
+    case block
+    
+    var title: String {
+        switch self {
+        case .modify: return "수정하기"
+        case .delete: return "삭제하기"
+        case .toAnonymous: return "익명으로 변경"
+        case .report: return "신고하기"
+        case .block: return "글쓴이 차단하기"
+        }
+    }
+    
+    var action: ((String) -> Void) {
+        switch self {
+        case .modify:
+           return { targetID in
+                print(targetID, "수정하기")
+            }
+        default:
+            return { targetID in
+               print(targetID)
+            }
+        }
+    }
+}

--- a/DoriDori_iOS/DoriDori_iOS/Scene/WebView/DoriDoriWeb.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/WebView/DoriDoriWeb.swift
@@ -10,8 +10,8 @@ import Foundation
 typealias PostID = String
 
 enum DoriDoriWeb {
-    case questionDetail(id: QuestionID)
-    case postDetail(id: PostID)
+    case questionDetail(id: QuestionID, isMyQuestion: Bool)
+    case postDetail(id: PostID, isMyPost: Bool)
     case profileSetting
     case share(id: UserID? = nil)
     case myLevel
@@ -23,8 +23,8 @@ enum DoriDoriWeb {
     
     var path: String {
         switch self {
-        case .questionDetail(let questionID): return "/question-detail?questionId=\(questionID)"
-        case .postDetail(let postID): return "/post-detail?postId=\(postID)"
+        case .questionDetail(let questionID, _): return "/question-detail?questionId=\(questionID)"
+        case .postDetail(let postID, _): return "/post-detail?postId=\(postID)"
         case .profileSetting: return "/setting/my-profile"
         case .share(let userID):
             if let userID = userID {

--- a/DoriDori_iOS/DoriDori_iOS/Scene/WebView/DoriDoriWeb.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/WebView/DoriDoriWeb.swift
@@ -10,8 +10,8 @@ import Foundation
 typealias PostID = String
 
 enum DoriDoriWeb {
-    case questionDetail(id: QuestionID, isMyQuestion: Bool)
-    case postDetail(id: PostID, isMyPost: Bool)
+    case questionDetail(id: QuestionID, questionUserID: UserID)
+    case postDetail(id: PostID, postUserID: UserID)
     case profileSetting
     case share(id: UserID? = nil)
     case myLevel

--- a/DoriDori_iOS/DoriDori_iOS/Scene/WebView/NavigationWebViewController.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/WebView/NavigationWebViewController.swift
@@ -175,6 +175,8 @@ final class NavigationWebViewController: UIViewController {
                                         .disposed(by: self.disposeBag)
                                 case .block:
                                     self.blockUser(userID: postUserID)
+                                case .report:
+                                    self.report(type: .post, targetID: postID)
                                 default: break
                                 }
                             })
@@ -196,6 +198,8 @@ final class NavigationWebViewController: UIViewController {
                                         .disposed(by: self.disposeBag)
                                 case .block:
                                     self.blockUser(userID: questionUserID)
+                                case .report:
+                                    self.report(type: .question, targetID: questionID)
                                 default: break
                                 }
                             })
@@ -216,6 +220,16 @@ final class NavigationWebViewController: UIViewController {
             .observe(on: MainScheduler.instance)
             .bind(with: self) { owner, _ in
                 DoriDoriToastView(text: "해당 글쓴이를 차단했습니다.").show()
+            }
+            .disposed(by: self.disposeBag)
+    }
+    
+    private func report(type: ReportType, targetID: String) {
+        self.repository.report(type: type, targetID: targetID)
+            .filter { $0 }
+            .observe(on: MainScheduler.instance)
+            .bind(with: self) { owner, _ in
+                DoriDoriToastView(text: "신고가 정상 접수되었습니다.").show()
             }
             .disposed(by: self.disposeBag)
     }

--- a/DoriDori_iOS/DoriDori_iOS/Scene/WebView/NavigationWebViewController.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/WebView/NavigationWebViewController.swift
@@ -122,7 +122,7 @@ final class NavigationWebViewController: UIViewController {
         }
         
         switch self.type {
-        case .questionDetail:
+        case .questionDetail, .postDetail:
             self.setupQuestionDetailView()
         default: break
         }
@@ -143,6 +143,42 @@ final class NavigationWebViewController: UIViewController {
         self.backButton.rx.throttleTap
             .bind(with: self) { owner, _ in
                 owner.coordinator.pop()
+            }
+            .disposed(by: self.disposeBag)
+        
+        self.questionMoreButton.rx.throttleTap
+            .compactMap { [weak self] _ -> [ActionSheetAction]? in
+                guard let self = self else { return nil }
+                switch self.type {
+                case .postDetail(_, let isMine), .questionDetail(_, let isMine):
+                    if isMine {
+                        return [
+                            .init(title: "수정하기", action: { [weak self] _ in
+                                
+                            }),
+                            .init(title: "삭제하기", action: { [weak self] _ in
+                                
+                            }),
+                            .init(title: "익명으로 변경", action: { [weak self] _ in
+                                
+                            })
+                        ]
+                    } else {
+                        return [
+                            .init(title: "신고하기", action: { [weak self] _ in
+                                
+                            }),
+                            .init(title: "글쓴이 차단하기", action: { [weak self] _ in
+                                
+                            })
+                        ]
+                    }
+                default: return nil
+                }
+            }
+            .bind(with: self) { owner, actions in
+                let actionSheetViewController = ActionSheetAlertController(actionModels: actions).configure()
+                owner.present(actionSheetViewController, animated: true)
             }
             .disposed(by: self.disposeBag)
     }

--- a/DoriDori_iOS/DoriDori_iOS/Scene/WebView/NavigationWebViewController.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/WebView/NavigationWebViewController.swift
@@ -211,6 +211,12 @@ final class NavigationWebViewController: UIViewController {
     }
     
     private func blockUser(userID: UserID) {
-        
+        self.repository.blockUser(userID: userID)
+            .filter { $0 }
+            .observe(on: MainScheduler.instance)
+            .bind(with: self) { owner, _ in
+                DoriDoriToastView(text: "해당 글쓴이를 차단했습니다.").show()
+            }
+            .disposed(by: self.disposeBag)
     }
 }

--- a/DoriDori_iOS/DoriDori_iOS/Scene/WebView/NavigationWebViewController.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/WebView/NavigationWebViewController.swift
@@ -155,11 +155,12 @@ final class NavigationWebViewController: UIViewController {
         
         self.questionMoreButton.rx.throttleTap
             .compactMap { [weak self] _ -> [ActionSheetAction]? in
-                guard let self = self else { return nil }
+                guard let self = self,
+                      let userID = UserDefaults.userID else { return nil }
                 switch self.type {
-                case .postDetail(let postID, let isMine):
+                case .postDetail(let postID, let postUserID):
                     let items: [DoriDoriQuestionPostDetailMore]
-                    if isMine { items = [.modify, .delete] }
+                    if userID == postUserID { items = [.delete] }
                     else { items = [.report, .block] }
                     return items.map { item in
                             .init(title: item.title, action: { _ in
@@ -172,13 +173,15 @@ final class NavigationWebViewController: UIViewController {
                                             owner.coordinator.pop()
                                         })
                                         .disposed(by: self.disposeBag)
+                                case .block:
+                                    self.blockUser(userID: postUserID)
                                 default: break
                                 }
                             })
                     }
-                case .questionDetail(let questionID, let isMine):
+                case .questionDetail(let questionID, let questionUserID):
                     let items: [DoriDoriQuestionPostDetailMore]
-                    if isMine { items = [.modify, .delete] }
+                    if userID == questionUserID { items = [.modify, .delete] }
                     else { items = [.report, .block] }
                     return items.map { item in
                             .init(title: item.title, action: { _ in
@@ -191,6 +194,8 @@ final class NavigationWebViewController: UIViewController {
                                             owner.coordinator.pop()
                                         })
                                         .disposed(by: self.disposeBag)
+                                case .block:
+                                    self.blockUser(userID: questionUserID)
                                 default: break
                                 }
                             })
@@ -205,7 +210,7 @@ final class NavigationWebViewController: UIViewController {
             .disposed(by: self.disposeBag)
     }
     
-    private func deleteQuestion(questionID: QuestionID) {
+    private func blockUser(userID: UserID) {
         
     }
 }

--- a/DoriDori_iOS/DoriDori_iOS/Scene/WebView/NavigationWebViewController.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/WebView/NavigationWebViewController.swift
@@ -150,28 +150,12 @@ final class NavigationWebViewController: UIViewController {
             .compactMap { [weak self] _ -> [ActionSheetAction]? in
                 guard let self = self else { return nil }
                 switch self.type {
-                case .postDetail(_, let isMine), .questionDetail(_, let isMine):
-                    if isMine {
-                        return [
-                            .init(title: "수정하기", action: { [weak self] _ in
-                                
-                            }),
-                            .init(title: "삭제하기", action: { [weak self] _ in
-                                
-                            }),
-                            .init(title: "익명으로 변경", action: { [weak self] _ in
-                                
-                            })
-                        ]
-                    } else {
-                        return [
-                            .init(title: "신고하기", action: { [weak self] _ in
-                                
-                            }),
-                            .init(title: "글쓴이 차단하기", action: { [weak self] _ in
-                                
-                            })
-                        ]
+                case .postDetail(let targetID, let isMine), .questionDetail(let targetID, let isMine):
+                    let items: [DoriDoriQuestionPostDetailMore]
+                    if isMine { items = [.modify, .delete, .toAnonymous] }
+                    else { items = [.report, .block] }
+                    return items.map { item in
+                        .init(title: item.title, action: { _ in item.action(targetID) })
                     }
                 default: return nil
                 }

--- a/DoriDori_iOS/DoriDori_iOS/Scene/WebView/QuestionPostDetailRequestable.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/WebView/QuestionPostDetailRequestable.swift
@@ -1,0 +1,23 @@
+//
+//  QuestionPostDetailRequestable.swift
+//  DoriDori_iOS
+//
+//  Created by Seori on 2022/09/26.
+//
+
+import Foundation
+import RxSwift
+
+protocol QuestionPostDetailRequestable: AnyObject {
+    func deleteQuestion(questionID: QuestionID) -> Observable<String>
+    func deletePost(postID: PostID) -> Observable<Bool>
+}
+
+final class QuestionPostDetailRepository: QuestionPostDetailRequestable {
+    func deleteQuestion(questionID: QuestionID) -> Observable<String> {
+        Network().request(api: DeleteQuestionRequest(questionID: questionID), responseModel: ResponseModel<String>.self)
+    }
+    func deletePost(postID: PostID) -> Observable<Bool> {
+        Network().request(api: DeletePostRequest(postID: postID), responseModel: ResponseModel<Bool>.self)
+    }
+}

--- a/DoriDori_iOS/DoriDori_iOS/Scene/WebView/QuestionPostDetailRequestable.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/WebView/QuestionPostDetailRequestable.swift
@@ -11,6 +11,7 @@ import RxSwift
 protocol QuestionPostDetailRequestable: AnyObject {
     func deleteQuestion(questionID: QuestionID) -> Observable<String>
     func deletePost(postID: PostID) -> Observable<Bool>
+    func blockUser(userID: UserID) -> Observable<Bool>
 }
 
 final class QuestionPostDetailRepository: QuestionPostDetailRequestable {
@@ -19,5 +20,9 @@ final class QuestionPostDetailRepository: QuestionPostDetailRequestable {
     }
     func deletePost(postID: PostID) -> Observable<Bool> {
         Network().request(api: DeletePostRequest(postID: postID), responseModel: ResponseModel<Bool>.self)
+    }
+    
+    func blockUser(userID: UserID) -> Observable<Bool> {
+        Network().request(api: BlockUserRequest(userID: userID), responseModel: ResponseModel<Bool>.self)
     }
 }

--- a/DoriDori_iOS/DoriDori_iOS/Scene/WebView/QuestionPostDetailRequestable.swift
+++ b/DoriDori_iOS/DoriDori_iOS/Scene/WebView/QuestionPostDetailRequestable.swift
@@ -12,6 +12,7 @@ protocol QuestionPostDetailRequestable: AnyObject {
     func deleteQuestion(questionID: QuestionID) -> Observable<String>
     func deletePost(postID: PostID) -> Observable<Bool>
     func blockUser(userID: UserID) -> Observable<Bool>
+    func report(type: ReportType, targetID: String) -> Observable<Bool>
 }
 
 final class QuestionPostDetailRepository: QuestionPostDetailRequestable {
@@ -24,5 +25,9 @@ final class QuestionPostDetailRepository: QuestionPostDetailRequestable {
     
     func blockUser(userID: UserID) -> Observable<Bool> {
         Network().request(api: BlockUserRequest(userID: userID), responseModel: ResponseModel<Bool>.self)
+    }
+    
+    func report(type: ReportType, targetID: String) -> Observable<Bool> {
+        Network().request(api: ReportRequest(type: type, targetID: targetID), responseModel: ResponseModel<Bool>.self)
     }
 }


### PR DESCRIPTION
#103 
내용 간단히 설명드리면
post, question에서 셀 클릭시 이동하는 웹뷰의 navigation bar에 있는 ... 클릭시 나오는 action sheet 만들어서 작업했습니다~
작업하다보니느낀건데 이 부분도 웹이 다 가져갔어야 깔끔하지않았나.. 왜 굳이 이 부분을 네이티브에서 했어야하는가에대한 생각이 조금 들었습니다. 버튼 이벤트같은건 post message로 받으면 충분히 처리할 수 있을 것 같은데 라는 생각?
아무튼 그렇게하면 작업이 너무 커질 것 같아서 코드는 좀 더럽지만 동작할 수 있도록 구현해두었어요.
기획이 post, question에서 상세 이동할 때 "본인글" 인지 "타인글" 인지에따라 액션시트에들어가는 액션이 달라야해서, userID값을 받아서 이동할 수 있도록 수정하는 부분이 들어갔어요ㅠㅠ 그렇지않으면 질문상세들어갔을 때 웹에서도 한 번, 네이티브에서도 한 번 api를 호출해야할 것 같아서.. 
alert으로 보여줘야하는 부분은 .. 그냥 토스트로 대체했습니다. ! 
익명으로 변경하기는 api가 안나온 것 같아서 지웠고 수정하기는 추후에 해도될 것 같아서 임의로 제거했어요. ㅎ

| 상대방 post 혹은 question | 나의 post 혹은 question |
|---|---|
|<img src= "https://user-images.githubusercontent.com/42825223/192297090-55d56d81-ce39-4e76-8cec-efa69040f491.png" width = 200>| <img src= "https://user-images.githubusercontent.com/42825223/192297178-b6784818-de8e-4352-adb1-b6c9c87333c6.png" width = 200>|
